### PR TITLE
Fixed cross-platform hot-keys

### DIFF
--- a/keymaps/build.cson
+++ b/keymaps/build.cson
@@ -1,3 +1,7 @@
-'atom-workspace':
+'.platform-darwin atom-workspace':
   'alt-cmd-b': 'build:sf-deploy-file'
   'alt-cmd-r': 'build:sf-retrieve-unpackaged-file'
+
+'.platform-win32 atom-workspace, .platform-linux atom-workspace':
+  'alt-ctrl-u': 'build:sf-deploy-file'
+  'alt-ctrl-r': 'build:sf-retrieve-unpackaged-file'


### PR DESCRIPTION
Tested on Windows 7/10 and Ubuntu (on VMware)
On windows hotkey for deploy single file changed letter - alt-ctrl-U for compatibility
