### PR TITLE
Several files commands

### DIFF
--- a/lib/build.coffee
+++ b/lib/build.coffee
@@ -53,7 +53,6 @@ module.exports =
     if jsonParam
         cmd += ' -D' + optype + '.several.json="' + jsonParam + '"'
     cmd += ' -f ' + @root + '/build/build.xml'
-    atom.notifications.addError(cmd, dismissable: true)
     return cmd
 
   startNewBuild:(buildTarget, params, buildType) ->
@@ -246,8 +245,7 @@ module.exports =
                   else
                       if fileParams.fileNameParsed not in params[fileParams.metaDataType].items && fileParams.fileNameParsed.length > 0
                           params[fileParams.metaDataType].items.push(fileParams.fileNameParsed)
-          params = JSON.stringify(params).replace(/"/g, '\\"');;
-          params =
+          params = JSON.stringify(params).replace(/"/g, '\\"');
           if @child then @abort(=> @startNewBuild(optype, params, 'buildSeveral')) else @startNewBuild(optype, params, 'buildSeveral')
 
   stop: ->

--- a/lib/build.coffee
+++ b/lib/build.coffee
@@ -246,7 +246,8 @@ module.exports =
                   else
                       if fileParams.fileNameParsed not in params[fileParams.metaDataType].items && fileParams.fileNameParsed.length > 0
                           params[fileParams.metaDataType].items.push(fileParams.fileNameParsed)
-          params = JSON.stringify(params);
+          params = JSON.stringify(params).replace(/"/g, '\\"');;
+          params =
           if @child then @abort(=> @startNewBuild(optype, params, 'buildSeveral')) else @startNewBuild(optype, params, 'buildSeveral')
 
   stop: ->

--- a/menus/build.cson
+++ b/menus/build.cson
@@ -18,3 +18,8 @@
         { 'label': 'Force.com : Retrieve File', 'command': 'build:sf-retrieve-unpackaged-file-treeview' },
         {'type': 'separator'}
     ]
+    '.tree-view.multi-select': [
+        { 'label': 'Force.com : Build Files', 'command': 'build:sf-deploy-several-files' },
+        { 'label': 'Force.com : Retrieve Files', 'command': 'build:sf-retrieve-several-files' },
+        {'type': 'separator'}
+    ]

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
       "build:sf-deploy-static-res",
       "build:sf-deploy-apex",
       "build:sf-deploy-visualforce",
+      "build:sf-deploy-several-files",
       "build:sf-abort",
       "build:sf-retrieve-unpackaged",
       "build:sf-retrieve-unpackaged-file",
-      "build:sf-retrieve-unpackaged-file-treeview"
+      "build:sf-retrieve-unpackaged-file-treeview",
+      "build:sf-retrieve-several-files"
     ]
   },
   "repository": "https://github.com/jonathanrico/forcedotcom-builder",


### PR DESCRIPTION
I could not sleep last night and wrote it :neckbeard:
It's a pretty big change.
I added the ability to select multiple files and deploy/retrieve them from the Org.

First of all, I added more or less clever sorting of the files which are selected (folders are not considered, meta files are recognized and added as sources, I haven't errors with this).
Also, I've been wanting to add the ability to deploy/retrieve EmailTemplates.
Also, I performed a little refactoring things in the code.

The lack of this feature - you need to add a new task in build.xml.
This task is quite bulky, but I believe this is the only elegant solution for this.
Solution created with scripts of the ant. I decided to choose Javascript.
Below is the code for this build.xml task. Just add this code to build.xml (I add this code to [pastebin](http://pastebin.com/MUmY9yRS). Also, I created [this merge request](https://github.com/jonathanrico/forcedotcom-project/pull/1).)

I tested this functionality only on Windows, but provided Linux and Darwin platforms.
Please test these changes, I hope they will be useful for you :bowtie:
